### PR TITLE
Fix duplicated tools

### DIFF
--- a/src/airline_agent/cleanlab_utils/validate_utils.py
+++ b/src/airline_agent/cleanlab_utils/validate_utils.py
@@ -172,16 +172,10 @@ def _get_tools_from_agent(agent: Agent) -> list[ToolDefinition]:
         List of ToolDefinition objects
     """
     tool_definitions = []
-
-    # Get tools from the function toolset (tools defined on the agent directly)
-    function_toolset = getattr(agent, "_function_toolset", None)
-    if function_toolset and getattr(function_toolset, "tools", None):
-        tool_definitions.extend([tool.tool_def for tool in getattr(function_toolset, "tools", {}).values()])
-    # Get tools from simple toolsets that don't require RunContext
     for toolset in agent.toolsets:
         if hasattr(toolset, "tools") and isinstance(toolset.tools, dict):
             tool_definitions.extend([tool.tool_def for tool in toolset.tools.values() if hasattr(tool, "tool_def")])
-    return list({t.name: t for t in tool_definitions}.values())
+    return tool_definitions
 
 
 def get_tools_in_openai_format(agent: Agent) -> list[ChatCompletionFunctionToolParam]:


### PR DESCRIPTION
In `src/airline_agent/cleanlab_utils/validate_utils.py::_get_tools_from_agent`, the `tools` passed to `project.validate` are duplicated. 

```
def _get_tools_from_agent(agent: Agent) -> list[ToolDefinition]:
    """Get tool definitions from an agent.

    This works for simple agents where tools are defined directly on the agent
    (e.g., via @agent.tool decorators or tools=[...] in constructor).

    Args:
        agent: The pydantic-ai Agent instance

    Returns:
        List of ToolDefinition objects
    """
    tool_definitions = []

    # Get tools from the function toolset (tools defined on the agent directly)
    function_toolset = getattr(agent, "_function_toolset", None)
    if function_toolset and getattr(function_toolset, "tools", None):
        tool_definitions.extend([tool.tool_def for tool in getattr(function_toolset, "tools", {}).values()])
    # Get tools from simple toolsets that don't require RunContext
    for toolset in agent.toolsets:
        if hasattr(toolset, "tools") and isinstance(toolset.tools, dict):
            tool_definitions.extend([tool.tool_def for tool in toolset.tools.values() if hasattr(tool, "tool_def")])
    return list({t.name: t for t in tool_definitions}.values())
```

Both loops each gave the same list of tools in our use case. I suppose there are edge cases so I just made a one-line change to deduplicate. But if it turns out we only need to use one of them then we could also just remove the other.
