### PR TITLE
[FE] Make Tool Calls collapsible / closed by default, remove eval scores

### DIFF
--- a/frontend/components/chat-list.tsx
+++ b/frontend/components/chat-list.tsx
@@ -7,7 +7,6 @@ import type { StoreMessage } from '@/stores/messages-store'
 
 import logoLightMode from './assets/logo-black.png'
 import logoDarkMode from './assets/logo-white.png'
-import { cn } from '@/lib/utils/tailwindUtils'
 import type { RefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { useAutoScrollMessage } from '../lib/hooks/use-auto-scroll-message'
@@ -129,12 +128,12 @@ const ChatMessage = ({
         }
 
         return (
-          <div className={cn('rounded-4 border border-border-2 bg-surface-1')}>
+          <div className="rounded-4 border border-border-2 bg-surface-1">
             <div className="flex items-start gap-4">
               <Collapsible.Root className="group/collapsible group flex-1">
                 <Collapsible.Trigger className="type-body-200-semibold flex w-full items-center justify-between gap-5 rounded-4 px-6 py-7 hover:bg-surface-1-hover">
-                  <div className="flex items-center gap-4">
-                    <span className="text-xs font-medium">🔧</span> Tool Call:{' '}
+                  <div className="type-body-200-semibold flex items-center gap-4">
+                    <span>🔧</span> Tool Call:{' '}
                     {toolCallData?.tool_name || 'Unknown'}
                   </div>
                   <IconChevronDown


### PR DESCRIPTION
<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- Implementation plan: link
- Priority: urgent
<!-- priority is low, normal, or urgent; for low or urgent, include your expected deadline -->

## What changed?

- Switches Tool Call component to use a Radix UI Collapsible with open and closing animations
- Hides the scores / issues accordion in MessageAssistant component
- Misc: removes some Tailwind classes that do nothing

https://github.com/user-attachments/assets/168010d6-df69-4f2a-8bef-b7000b47cc5e



## What do you want the reviewer(s) to focus on?
- Ensure eval scores accordion is gone
- Test that tool call collapsibles look and feel nice

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
