### PR TITLE
log empty eval scores instead for tool calls

### DIFF
--- a/src/airline_agent/cleanlab_utils/validate_utils.py
+++ b/src/airline_agent/cleanlab_utils/validate_utils.py
@@ -20,7 +20,13 @@ from openai.types.chat import (
     ChatCompletionFunctionToolParam,
     ChatCompletionMessageParam,
 )
-from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, SystemPromptPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    UserPromptPart,
+)
 
 from airline_agent.cleanlab_utils.conversion_utils import (
     convert_message_to_chat_completion,
@@ -28,11 +34,7 @@ from airline_agent.cleanlab_utils.conversion_utils import (
     convert_to_openai_messages,
     convert_tools_to_openai_format,
 )
-from airline_agent.constants import (
-    CONTEXT_RETRIEVAL_TOOLS,
-    FALLBACK_RESPONSE,
-    get_perfect_eval_scores,
-)
+from airline_agent.constants import CONTEXT_RETRIEVAL_TOOLS, FALLBACK_RESPONSE
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +153,9 @@ def _get_final_response_message(
     return response, None
 
 
-def _get_system_messages(message_history: list[ModelMessage]) -> list[ChatCompletionMessageParam]:
+def _get_system_messages(
+    message_history: list[ModelMessage],
+) -> list[ChatCompletionMessageParam]:
     """Get system messages to prepend to validation messages."""
     system_messages: list[ChatCompletionMessageParam] = []
     instructions_added = False
@@ -162,7 +166,10 @@ def _get_system_messages(message_history: list[ModelMessage]) -> list[ChatComple
             # Extract instructions and add as system message only once
             if hasattr(message, "instructions") and message.instructions and not instructions_added:
                 system_messages.append(
-                    cast(ChatCompletionMessageParam, {"role": "system", "content": message.instructions})
+                    cast(
+                        ChatCompletionMessageParam,
+                        {"role": "system", "content": message.instructions},
+                    )
                 )
                 instructions_added = True
 
@@ -170,7 +177,10 @@ def _get_system_messages(message_history: list[ModelMessage]) -> list[ChatComple
             for part in message.parts:
                 if isinstance(part, SystemPromptPart) and part.content not in system_prompts_seen:
                     system_messages.append(
-                        cast(ChatCompletionMessageParam, {"role": "system", "content": part.content})
+                        cast(
+                            ChatCompletionMessageParam,
+                            {"role": "system", "content": part.content},
+                        )
                     )
                     system_prompts_seen.add(part.content)
 
@@ -312,7 +322,7 @@ def run_cleanlab_validation_logging_tools(
                 context=_get_context_as_string(openai_new_messages),
                 tools=tools,
                 metadata={"thread_id": thread_id} if thread_id else None,
-                eval_scores=get_perfect_eval_scores(),
+                eval_scores={},
             )
             logger.info("[cleanlab] Logging function call, automatic validation pass.")
 

--- a/src/airline_agent/constants.py
+++ b/src/airline_agent/constants.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 
 logger = logging.getLogger(__name__)
@@ -35,43 +34,3 @@ documents about the airline's services, policies, and procedures.
 )
 
 FALLBACK_RESPONSE = "I'm sorry, but I don't have the information you're looking for. Please rephrase the question or contact Frontier Airlines customer support for further assistance."
-
-
-@functools.cache
-def get_perfect_eval_scores() -> dict[str, float]:
-    """Get perfect eval scores, cached after first call."""
-    import os
-
-    from codex import Codex
-    from dotenv import load_dotenv
-
-    load_dotenv()  # Ensure .env is loaded before accessing environment variables
-    api_key = os.getenv("CODEX_API_KEY")
-    project_id = os.getenv("CLEANLAB_PROJECT_ID")
-
-    if not api_key or not project_id:
-        logger.warning("CODEX_API_KEY or CLEANLAB_PROJECT_ID environment variable is not set")
-        return {}
-
-    client = Codex(api_key=api_key)
-    project = client.projects.retrieve(project_id)
-    eval_config = project.config.eval_config
-
-    if not eval_config:
-        logger.warning("No eval_config found in project")
-        return {}
-
-    eval_keys = []
-
-    # Add default evals if they exist
-    if eval_config.default_evals:
-        default_evals_dump = eval_config.default_evals.model_dump()
-        if default_evals_dump:
-            eval_keys.extend([evaluation["eval_key"] for evaluation in default_evals_dump.values()])
-
-    # Add custom evals if they exist
-    if eval_config.custom_evals and eval_config.custom_evals.evals:
-        eval_keys.extend([evaluation.eval_key for evaluation in eval_config.custom_evals.evals.values()])
-
-    logger.info("Retrieved evals: %s", eval_keys)
-    return {eval_key: 1.0 for eval_key in eval_keys}


### PR DESCRIPTION
## What changed?

Context in [this slack thread](https://cleanlabinc.slack.com/archives/C09H6K312R4/p1761158220579059?thread_ts=1761105306.135509&cid=C09H6K312R4). TL;DR there's no reason to log fake passing eval scores when logging tool calls. We can just pass an empty dict.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [x] _What QA did you do?_
  - Tested...
