### PR TITLE
disable guidance when cleanlab disabled

### DIFF
--- a/src/airline_agent/backend/services/airline_chat.py
+++ b/src/airline_agent/backend/services/airline_chat.py
@@ -121,7 +121,6 @@ async def airline_chat_streaming(
         guidance = consult_cleanlab(original_user_query, thread_to_messages[thread_id])
         user_prompt = update_prompt_with_guidance(original_user_query, guidance)
     else:
-        guidance = []
         user_prompt = original_user_query
 
     original_message_history = thread_to_messages[thread_id].copy()


### PR DESCRIPTION
## What changed?

An oversight in the original implementation. We should skip checking for guidance and updating prompt if cleanlab is disabled.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
