### PR TITLE
Add expert review example

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,14 +542,14 @@ In this case, because the user’s question already specifies both the type of f
 
 #### To explore Expert Review guardrail
 
-> *does frontier accomodate passengers with allergies*
+> *do i have to worry about losing my miles because frontier decides to shut its miles program?*
 
 <details>
   <summary>Learn More</summary>
 
 ```text
 AI Response without Cleanlab:
-Frontier Airlines cannot guarantee an allergen-free environment on its flights due to the presence of food allergens in the snacks served and the possibility of passengers bringing products containing nuts or other allergens onboard. If you have a severe nut or food allergy, you should notify a flight attendant so they can attempt to inform nearby passengers to refrain from eating allergen-containing products. However, the airline cannot prevent passengers from consuming their own food. It's recommended to consult with your physician regarding any health concerns before flying.
+Frontier Airlines reserves the right to change its Frontier Miles program, including its terms and conditions, at any time without notice. This means that while there is always the potential risk that a miles program could be modified or terminated, such changes could also come with advance notice giving members an opportunity to use their accrued miles. It’s a good idea to regularly check any updates from Frontier regarding the program policies and terms.
 ```
 
 Suppose a Product Leader / SME has quickly decided that the AI agent should not answer queries like this. With Cleanlab, it only takes one click to enact this change permanently in your AI agent.
@@ -558,7 +558,7 @@ Expand this Log entry in the Project and click `No` under *Is this a good AI res
 
 Then pretend you are a different user **by creating a new chat thread** and ask a similar query:
 
-> *does frontier accomodate passengers with allergies*
+> *do i have to worry about losing my miles because frontier decides to shut its miles program?*
 
 You'll see that Cleanlab now guardrails the AI, permanently preventing the response that was just deemed undesirable. This allows nontechnical SMEs to reduce false negatives in Guardrails (as well as false positives by clicking `Yes` under *Is this a good AI response?*).
 <br><br>

--- a/tests/stable/test_remediations.py
+++ b/tests/stable/test_remediations.py
@@ -47,6 +47,25 @@ def test_expert_review(project: Project) -> None:
     assert log2.guardrailed
 
 
+@pytest.mark.additional
+def test_additional_expert_review(project: Project) -> None:
+    question1 = "do i have to worry about losing my miles because frontier decides to shut its miles program?"
+    question2 = "do i have to worry about losing my miles because frontier decides to shut its miles program?"
+
+    agent1 = Agent()
+    print("QUESTION:", question1)  # noqa: T201
+    _, log_id1 = agent1.chat(question1)
+    assert log_id1 is not None
+    log1 = wait_and_get_final_log_for(project, log_id1)
+    project.add_expert_review(log1.id, is_good=False)
+
+    agent2 = Agent()
+    _, log_id2 = agent2.chat(question2)
+    assert log_id2 is not None
+    log2 = wait_and_get_final_log_for(project, log_id2)
+    assert log2.guardrailed
+
+
 @pytest.mark.main
 def test_ai_guidance(project: Project) -> None:
     question1 = "what is the cheapest Frontier flight from SFO to NYC on 11/11?"


### PR DESCRIPTION
New expert review example:

> do i have to worry about losing my miles because frontier decides to shut its miles program?

I don't think Frontier will want their chatbot to answer this question. It's a rare situation that they have a term just for legal reasons. AI response reinforces the policy that Frontier has the right to shut the program and can unnecessarily cause passengers to stress about this.

Outdated:

Added to additional examples section:

```
### To explore Expert Review guardrail

> *does frontier accomodate passengers with allergies*

<details>
  <summary>Learn More</summary>

\```text
AI Response without Cleanlab:
Frontier Airlines cannot guarantee an allergen-free environment on its flights due to the presence of food allergens in the snacks served and the possibility of passengers bringing products containing nuts or other allergens onboard. If you have a severe nut or food allergy, you should notify a flight attendant so they can attempt to inform nearby passengers to refrain from eating allergen-containing products. However, the airline cannot prevent passengers from consuming their own food. It's recommended to consult with your physician regarding any health concerns before flying.
\```

Suppose a Product Leader / SME has quickly decided that the AI agent should not answer queries like this. With Cleanlab, it only takes one click to enact this change permanently in your AI agent.

Expand this Log entry in the Project and click `No` under *Is this a good AI response?*, and click `Submit`.

Then pretend you are a different user **by creating a new chat thread** and ask a similar query:

> *does frontier accomodate passengers with allergies*

You'll see that Cleanlab now guardrails the AI, permanently preventing the response that was just deemed undesirable. This allows nontechnical SMEs to reduce false negatives in Guardrails (as well as false positives by clicking `Yes` under *Is this a good AI response?*).
<br><br>
</details>
```