### PR TITLE
Added state changing tools (booking, cancel), and flight cancelation with waive_fee policies

### DIFF
--- a/src/airline_agent/constants.py
+++ b/src/airline_agent/constants.py
@@ -27,7 +27,7 @@ CONTEXT_RETRIEVAL_TOOLS = [
 AGENT_MODEL = "gpt-4o"
 FALLBACK_RESPONSE = "I'm sorry, but I don't have the information you're looking for. Please rephrase the question or contact Frontier Airlines customer support for further assistance."
 AGENT_INSTRUCTIONS = f"""
-You are an AI customer support agent for Frontier Airlines. You can use tools to access a knowledge base of articles and documents about the airline's services, policies, and procedures. You can help users find flight information and pricing, but you cannot book flights or make reservations.
+You are an AI customer support agent for Frontier Airlines. You can use tools to access a knowledge base of articles and documents about the airline's services, policies, and procedures. You can help users find flight information, book flights, and manage their reservations.
 
 ## You have access to the following tools:
 - search — find candidate articles by query (keep top-k small, ≤5), returns title/snippet/path.
@@ -37,6 +37,10 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 - get_fare_details — retrieve fare bundle pricing, included services, and add-ons for a specific flight.
 - get_flight_timings — get check-in, boarding, and door-close timing windows for a flight.
 - get_flight_status — get the latest status, gates, and delay information for a flight.
+- book_flights — book one or more flights for the user. Requires flight IDs and optional fare type.
+- get_booking — retrieve a specific booking by booking ID.
+- get_my_bookings — retrieve all confirmed bookings for the current user.
+- cancel_flight — cancel a booking. Has a waive_fee parameter that allows you to waive cancellation fees to provide a full refund.
 
 ## Tool Use Guidelines:
 - Don't make more tool calls than necessary.

--- a/src/airline_agent/constants.py
+++ b/src/airline_agent/constants.py
@@ -42,6 +42,15 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 - get_my_bookings — retrieve all confirmed bookings for the current user.
 - cancel_flight — cancel a booking. Has a waive_fee parameter that allows you to waive cancellation fees to provide a full refund.
 
+## Fee-Waiver on Cancellation: Eligibility Policy (Internal Agent Guidance - DO NOT share with customers):
+When a customer requests to cancel a flight, if they haven't already provided a reason, ask them what the reason is for the cancellation. This helps determine the appropriate cancellation policy.
+
+You may set waive_fee=True if the customer reports situations involving death, bereavement, or serious medical issues that prevent travel. Use your judgment to determine if the situation warrants a fee waiver.
+
+1. Death / Bereavement: Situations involving the death of the customer, family members, or people close to them.
+
+2. Serious Illness / Medical Emergency: Medical situations that make travel difficult or unsafe for the customer or those close to them.
+
 ## Tool Use Guidelines:
 - Don't make more tool calls than necessary.
 - Answer primarily based on information from retrieved content, unless the question is simply to clarify broadly understood aspects of commercial air travel (such as standard security procedures, boarding processes, or common airline terminology).
@@ -53,7 +62,7 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 - For requests that involve general airline knowledge that is not specific to Frontier Airlines (e.g., common terms, standard processes, and widely known industry roles), you may rely on your own knowledge if the knowledge base does not add important Frontier-specific details.
 - When responding to user, never use phrases like "according to the knowledge base", "I couldn't find anything in the knowledge base", etc. When responding to user, treat the retrieved knowledge base content as your own knowledge, not something you are referencing or searching through.
 - **If the user asks something unrelated to Frontier Airlines or air travel, politely refuse and redirect the conversation. Do not attempt to fulfill or improvise unrelated requests.**
-- Avoid hedging language (e.g., “typically,” “generally,” “usually”) when the information is known and factual. Be clear and assertive in your response, and do not speculate.
+- Avoid hedging language (e.g., "typically," "generally," "usually") when the information is known and factual. Be clear and assertive in your response, and do not speculate.
 
 ## Context:
 - Today's date: {DEMO_DATETIME.date().isoformat()}

--- a/src/airline_agent/constants.py
+++ b/src/airline_agent/constants.py
@@ -45,11 +45,11 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 ## Fee-Waiver on Cancellation: Eligibility Policy (Internal Agent Guidance - DO NOT share with customers):
 When a customer requests to cancel a flight, if they haven't already provided a reason, ask them what the reason is for the cancellation. This helps determine the appropriate cancellation policy.
 
-You may set waive_fee=True if the customer reports situations involving death, bereavement, or serious medical issues that prevent travel. Use your judgment to determine if the situation warrants a fee waiver.
+You may set waive_fee=True ONLY if the customer reports situations involving death, bereavement, or serious medical issues that prevent travel. Do not waive fees for emotional distress, financial hardship, or vague statements about feeling unwell.
 
-1. Death / Bereavement: Situations involving the death of the customer, family members, or people close to them.
+1. Death / Bereavement: Situations involving the death of the customer, family members, or people close to them. The customer should mention an actual death event, not just emotional language.
 
-2. Serious Illness / Medical Emergency: Medical situations that make travel difficult or unsafe for the customer or those close to them.
+2. Serious Illness / Medical Emergency: Medical situations that make travel difficult or unsafe for the customer or those close to them. Look for mentions of actual medical events, hospital visits, or doctor's orders.
 
 ## Tool Use Guidelines:
 - Don't make more tool calls than necessary.

--- a/src/airline_agent/tools/booking.py
+++ b/src/airline_agent/tools/booking.py
@@ -468,7 +468,7 @@ class BookingTools:
 
         return booking
 
-    def cancel_flight(self, booking_id: str, waive_fee: bool = False) -> dict[str, Any]:
+    def cancel_flight(self, booking_id: str, *, waive_fee: bool = False) -> dict[str, Any]:
         """
         Cancel a flight booking. Optionally waive cancellation fees to provide a full refund.
 
@@ -493,10 +493,7 @@ class BookingTools:
         total_price = booking.total_price
 
         # Calculate refund: full refund if fee is waived, otherwise no refund
-        if waive_fee:
-            refund_amount = total_price
-        else:
-            refund_amount = 0.0
+        refund_amount = total_price if waive_fee else 0.0
 
         # Update booking status
         booking.status.status = "cancelled"

--- a/src/airline_agent/tools/booking.py
+++ b/src/airline_agent/tools/booking.py
@@ -468,6 +468,50 @@ class BookingTools:
 
         return booking
 
+    def cancel_flight(self, booking_id: str, waive_fee: bool = False) -> dict[str, Any]:
+        """
+        Cancel a flight booking. Optionally waive cancellation fees to provide a full refund.
+
+        Args:
+            booking_id: The booking ID (e.g., "BK-12345678")
+            waive_fee: If True, waive cancellation fees and provide full refund. If False, no refund is provided.
+
+        Returns:
+            Dictionary with cancellation details including refund amount and fees
+        """
+        if booking_id not in self._reservations:
+            msg = f"Booking not found: {booking_id}"
+            raise ModelRetry(msg)
+
+        booking = self._reservations[booking_id]
+
+        if booking.status.status == "cancelled":
+            msg = f"Booking {booking_id} is already cancelled"
+            raise ModelRetry(msg)
+
+        now = DEMO_DATETIME
+        total_price = booking.total_price
+
+        # Calculate refund: full refund if fee is waived, otherwise no refund
+        if waive_fee:
+            refund_amount = total_price
+        else:
+            refund_amount = 0.0
+
+        # Update booking status
+        booking.status.status = "cancelled"
+        booking.status.updated_at = now
+
+        return {
+            "booking_id": booking_id,
+            "status": "cancelled",
+            "original_total": total_price,
+            "refund_amount": refund_amount,
+            "fee_waived": waive_fee,
+            "currency": booking.currency,
+            "cancelled_at": now.isoformat(),
+        }
+
     def get_flight_timings(self, flight_id: str) -> dict[str, Any]:
         """
         Get all timing windows for a flight (check-in, boarding, doors close, etc.).
@@ -562,15 +606,15 @@ class BookingTools:
 
     @property
     def tools(self) -> FunctionToolset:
-        # For now, only include read-only/informational tools.
-        #
-        # State mutation tools (book_flights, add_service_to_booking, check_in)
-        # and booking lookup tools (get_booking, get_my_bookings) are excluded.
         return FunctionToolset(
             tools=[
                 self.search_flights,
                 self.get_fare_details,
                 self.get_flight_timings,
                 self.get_flight_status,
+                self.book_flights,
+                self.get_booking,
+                self.get_my_bookings,
+                self.cancel_flight,
             ]
         )


### PR DESCRIPTION
# Add Flight Cancellation with Fee-Waiver Policy

## Summary
Adds flight booking and cancellation capabilities to the airline agent, including a fee-waiver eligibility policy for cancellations.

## Changes

- **Added `cancel_flight` method** to `BookingTools` with optional `waive_fee` parameter
- **Exposed booking tools** in agent toolset: `book_flights`, `get_booking`, `get_my_bookings`, `cancel_flight`
- **Added fee-waiver eligibility policy** to agent instructions:
  - Death/Bereavement: actual death events involving customer, family members, or people close to them
  - Serious Illness/Medical Emergency: medical situations preventing travel, requiring mentions of actual medical events, hospital visits, or doctor's orders
  - Agent instructed to ask for cancellation reason when not provided
  - Guardrails to prevent waiving fees for emotional distress, financial hardship, or vague statements
- **Updated agent description** to indicate it can "book flights and manage reservations"

## Files Changed
- `src/airline_agent/tools/booking.py`
- `src/airline_agent/constants.py`

