### PR TITLE
Clean up observability report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ check = "mypy --strict {args:src tests}"
 [tool.pytest.ini_options]
 markers = [
     "main: marks tests for main demo examples",
-    "additional: marks tests for additional demo examples"
+    "additional: marks tests for additional demo examples",
+    "benign: marks tests for benign dataset examples"
 ]
 
 [tool.hatch.envs.hatch-test]

--- a/scripts/aggregate_test_results.py
+++ b/scripts/aggregate_test_results.py
@@ -65,9 +65,7 @@ def main() -> None:
         entry_question = extract_question(entry)
 
         if entry_question:
-            entry_time = datetime.datetime.strptime(entry["timestamp"], TIMESTAMP_FORMAT).replace(
-                tzinfo=datetime.UTC
-            )
+            entry_time = datetime.datetime.strptime(entry["timestamp"], TIMESTAMP_FORMAT).replace(tzinfo=datetime.UTC)
 
             if test_name not in latest_questions:
                 latest_questions[test_name] = (entry_question, entry_time)
@@ -78,7 +76,9 @@ def main() -> None:
 
     summary: dict[str, defaultdict[str, TestSummary]] = {
         "main": defaultdict(lambda: {"failures": 0, "passes": 0, "question": "", "test_names": [], "last_fail": None}),
-        "additional": defaultdict(lambda: {"failures": 0, "passes": 0, "question": "", "test_names": [], "last_fail": None}),
+        "additional": defaultdict(
+            lambda: {"failures": 0, "passes": 0, "question": "", "test_names": [], "last_fail": None}
+        ),
     }
 
     for entry in recent:
@@ -138,7 +138,7 @@ def main() -> None:
                         rate = (data["failures"] / total) * 100 if total else 0
                         display_question = data["question"] if data["question"] else question_key
                         if len(display_question) > MAX_QUESTION_DISPLAY_LENGTH:
-                            display_question = display_question[:MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
+                            display_question = display_question[: MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
                         md.write(f"| `{display_question}` | {data['failures']} | {data['passes']} | {rate:.0f}% |\n")
 
                     md.write("\n---\n\n#### 🔍 Main Test Failure Details\n\n")
@@ -177,7 +177,7 @@ def main() -> None:
                         rate = (data["failures"] / total) * 100 if total else 0
                         display_question = data["question"] if data["question"] else question_key
                         if len(display_question) > MAX_QUESTION_DISPLAY_LENGTH:
-                            display_question = display_question[:MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
+                            display_question = display_question[: MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
                         md.write(f"| `{display_question}` | {data['failures']} | {data['passes']} | {rate:.0f}% |\n")
 
                     md.write("\n---\n\n#### 🔍 Additional Test Failure Details\n\n")

--- a/scripts/aggregate_test_results.py
+++ b/scripts/aggregate_test_results.py
@@ -33,11 +33,16 @@ def extract_question(entry: dict) -> str | None:
     return None
 
 
-def is_timeout_failure(entry: dict) -> bool:
-    """Check if entry represents a timeout/connection failure."""
+def is_failure_log(entry: dict) -> bool:
+    """Check if entry represents a timeout/connection failure or InternalServerError."""
     stdout = entry.get("stdout", "").lower()
     error_msg = entry.get("error_msg", "").lower()
-    return "timeout" in stdout or "timeout" in error_msg
+    return (
+        "timeout" in stdout
+        or "timeout" in error_msg
+        or "internalservererror" in stdout
+        or "internalservererror" in error_msg
+    )
 
 
 def main() -> None:
@@ -57,7 +62,7 @@ def main() -> None:
         if datetime.datetime.strptime(x["timestamp"], TIMESTAMP_FORMAT).replace(tzinfo=datetime.UTC).date() >= cutoff
     ]
 
-    recent = [x for x in recent if not is_timeout_failure(x)]
+    recent = [x for x in recent if not is_failure_log(x)]
 
     latest_questions: dict[str, tuple[str, datetime.datetime]] = {}
     for entry in recent:

--- a/scripts/aggregate_test_results.py
+++ b/scripts/aggregate_test_results.py
@@ -23,7 +23,7 @@ class TestSummary(TypedDict):
     last_fail: dict[str, Any] | None
 
 
-def extract_question(entry: dict) -> str | None:
+def extract_question(entry: dict[str, Any]) -> str | None:
     """Extract question from entry stdout, return None if not found."""
     if not entry.get("stdout"):
         return None
@@ -33,7 +33,7 @@ def extract_question(entry: dict) -> str | None:
     return None
 
 
-def is_failure_log(entry: dict) -> bool:
+def is_failure_log(entry: dict[str, Any]) -> bool:
     """Check if entry represents a timeout/connection failure or InternalServerError."""
     stdout = entry.get("stdout", "").lower()
     error_msg = entry.get("error_msg", "").lower()

--- a/scripts/aggregate_test_results.py
+++ b/scripts/aggregate_test_results.py
@@ -12,13 +12,32 @@ DATA_FILE = ROOT_DIR / "stability_data.json"
 REPORT_FILE = ROOT_DIR / "README.md"
 
 REPORT_WINDOW_DAYS = 10
+MAX_QUESTION_DISPLAY_LENGTH = 80
 
 
 class TestSummary(TypedDict):
     failures: int
     passes: int
     question: str
+    test_names: list[str]
     last_fail: dict[str, Any] | None
+
+
+def extract_question(entry: dict) -> str | None:
+    """Extract question from entry stdout, return None if not found."""
+    if not entry.get("stdout"):
+        return None
+    matches = re.findall(r"^QUESTION:\s*(.+)$", entry["stdout"], flags=re.MULTILINE)
+    if matches:
+        return matches[0].strip()
+    return None
+
+
+def is_timeout_failure(entry: dict) -> bool:
+    """Check if entry represents a timeout/connection failure."""
+    stdout = entry.get("stdout", "").lower()
+    error_msg = entry.get("error_msg", "").lower()
+    return "timeout" in stdout or "timeout" in error_msg
 
 
 def main() -> None:
@@ -38,52 +57,57 @@ def main() -> None:
         if datetime.datetime.strptime(x["timestamp"], TIMESTAMP_FORMAT).replace(tzinfo=datetime.UTC).date() >= cutoff
     ]
 
+    recent = [x for x in recent if not is_timeout_failure(x)]
+
     latest_questions: dict[str, tuple[str, datetime.datetime]] = {}
     for entry in recent:
         test_name = entry["test_name"]
-        if entry.get("stdout"):
-            matches = re.findall(r"^QUESTION:\s*(.+)$", entry["stdout"], flags=re.MULTILINE)
-            for question_text in matches:
-                question = question_text.strip()
-                entry_time = datetime.datetime.strptime(entry["timestamp"], TIMESTAMP_FORMAT).replace(
-                    tzinfo=datetime.UTC
-                )
+        entry_question = extract_question(entry)
 
-                if test_name not in latest_questions:
-                    latest_questions[test_name] = (question, entry_time)
-                else:
-                    _, existing_time = latest_questions[test_name]
-                    if entry_time > existing_time:
-                        latest_questions[test_name] = (question, entry_time)
+        if entry_question:
+            entry_time = datetime.datetime.strptime(entry["timestamp"], TIMESTAMP_FORMAT).replace(
+                tzinfo=datetime.UTC
+            )
 
-    summary: defaultdict[str, TestSummary] = defaultdict(
-        lambda: {"failures": 0, "passes": 0, "question": "", "last_fail": None}
-    )
+            if test_name not in latest_questions:
+                latest_questions[test_name] = (entry_question, entry_time)
+            else:
+                _, existing_time = latest_questions[test_name]
+                if entry_time > existing_time:
+                    latest_questions[test_name] = (entry_question, entry_time)
+
+    summary: dict[str, defaultdict[str, TestSummary]] = {
+        "main": defaultdict(lambda: {"failures": 0, "passes": 0, "question": "", "test_names": [], "last_fail": None}),
+        "additional": defaultdict(lambda: {"failures": 0, "passes": 0, "question": "", "test_names": [], "last_fail": None}),
+    }
 
     for entry in recent:
         test_name = entry["test_name"]
-
-        entry_question = None
-        if entry.get("stdout"):
-            matches = re.findall(r"^QUESTION:\s*(.+)$", entry["stdout"], flags=re.MULTILINE)
-            if matches:
-                entry_question = matches[0].strip()
+        entry_question = extract_question(entry)
+        marker = entry.get("marker", "main")
 
         if test_name in latest_questions:
             latest_question, _ = latest_questions[test_name]
-            # Skip entries with old questions, but allow entries without questions
             if entry_question is not None and entry_question != latest_question:
                 continue
 
+        group_key = entry_question if entry_question else test_name
+
+        if marker not in summary:
+            marker = "main"
+
         outcome = entry["outcome"]
         if outcome == "failed":
-            summary[test_name]["failures"] += 1
-            summary[test_name]["last_fail"] = entry
+            summary[marker][group_key]["failures"] += 1
+            if summary[marker][group_key]["last_fail"] is None:
+                summary[marker][group_key]["last_fail"] = entry
         elif outcome == "passed":
-            summary[test_name]["passes"] += 1
+            summary[marker][group_key]["passes"] += 1
 
         if entry_question:
-            summary[test_name]["question"] = entry_question
+            summary[marker][group_key]["question"] = entry_question
+        if test_name not in summary[marker][group_key]["test_names"]:
+            summary[marker][group_key]["test_names"].append(test_name)
 
     with open(REPORT_FILE, "w") as md:
         md.write(f"### 🧩 Stability Summary ({today})\n")
@@ -92,35 +116,92 @@ def main() -> None:
         if not recent:
             md.write(f"⚠️ No recent tests ran in the last {REPORT_WINDOW_DAYS} days.\n")
         else:
-            flaky = {k: v for k, v in summary.items() if v["failures"] > 0}
-            if not flaky:
+            main_tests = summary["main"]
+            main_flaky = {k: v for k, v in main_tests.items() if v["failures"] > 0}
+
+            additional_tests = summary["additional"]
+            additional_flaky = {k: v for k, v in additional_tests.items() if v["failures"] > 0}
+
+            has_main_issues = len(main_flaky) > 0
+            has_additional_issues = len(additional_flaky) > 0
+
+            if not has_main_issues and not has_additional_issues:
                 md.write(f"✅ All tests passed consistently in the last {REPORT_WINDOW_DAYS} days.\n")
             else:
-                md.write("#### ❗ Flaky / Failing Tests\n")
-                md.write("| Test | Failures | Passes | Failure Rate |\n")
-                md.write("|------|-----------|--------|--------------|\n")
+                if has_main_issues:
+                    md.write("#### ❗ Main Tests (Must be 100% Stable)\n")
+                    md.write("| Question | Failures | Passes | Failure Rate |\n")
+                    md.write("|----------|----------|--------|--------------|\n")
 
-                for test_name, data in sorted(flaky.items()):
-                    total = data["failures"] + data["passes"]
-                    rate = (data["failures"] / total) * 100 if total else 0
-                    md.write(f"| `{test_name}` | {data['failures']} | {data['passes']} | {rate:.0f}% |\n")
+                    for question_key, data in sorted(main_flaky.items()):
+                        total = data["failures"] + data["passes"]
+                        rate = (data["failures"] / total) * 100 if total else 0
+                        display_question = data["question"] if data["question"] else question_key
+                        if len(display_question) > MAX_QUESTION_DISPLAY_LENGTH:
+                            display_question = display_question[:MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
+                        md.write(f"| `{display_question}` | {data['failures']} | {data['passes']} | {rate:.0f}% |\n")
 
-                md.write("\n---\n\n#### 🔍 Failure Details\n\n")
+                    md.write("\n---\n\n#### 🔍 Main Test Failure Details\n\n")
 
-                for test_name, data in sorted(flaky.items()):
-                    entry = data["last_fail"]
-                    md.write(f"##### `{test_name}`\n\n")
-                    md.write(f"**Failures:** {data['failures']} times\n\n")
-                    if data["question"]:
-                        md.write(f"**Question:** {data['question']}\n\n")
-                    if entry and entry.get("error_msg"):
-                        log = entry["error_msg"].strip()
-                        md.write("\n<details>\n")
-                        md.write("<summary><strong>View full failure log</strong></summary>\n\n")
-                        md.write("\n\n```\n")
-                        md.write(log)
-                        md.write("\n```\n")
-                        md.write("</details>\n\n---\n\n")
+                    for question_key, data in sorted(main_flaky.items()):
+                        entry = data["last_fail"]
+                        display_question = data["question"] if data["question"] else question_key
+                        md.write(f"##### `{display_question}`\n\n")
+                        md.write(f"**Failures:** {data['failures']} times\n\n")
+
+                        if data["test_names"]:
+                            test_names_str = ", ".join(f"`{tn}`" for tn in sorted(data["test_names"]))
+                            md.write(f"**Test Names:** {test_names_str}\n\n")
+
+                        if entry and entry.get("error_msg"):
+                            log = entry["error_msg"].strip()
+                            md.write("\n<details>\n")
+                            md.write("<summary><strong>View full failure log</strong></summary>\n\n")
+                            md.write("\n\n```\n")
+                            md.write(log)
+                            md.write("\n```\n")
+                            md.write("</details>\n\n---\n\n")
+
+                    md.write("\n")
+                else:
+                    md.write("#### ✅ Main Tests\n")
+                    md.write("All main tests passed consistently (100% stable).\n\n")
+
+                if has_additional_issues:
+                    md.write("#### 📊 Additional Tests (Some Instability Allowed)\n")
+                    md.write("| Question | Failures | Passes | Failure Rate |\n")
+                    md.write("|----------|----------|--------|--------------|\n")
+
+                    for question_key, data in sorted(additional_flaky.items()):
+                        total = data["failures"] + data["passes"]
+                        rate = (data["failures"] / total) * 100 if total else 0
+                        display_question = data["question"] if data["question"] else question_key
+                        if len(display_question) > MAX_QUESTION_DISPLAY_LENGTH:
+                            display_question = display_question[:MAX_QUESTION_DISPLAY_LENGTH - 3] + "..."
+                        md.write(f"| `{display_question}` | {data['failures']} | {data['passes']} | {rate:.0f}% |\n")
+
+                    md.write("\n---\n\n#### 🔍 Additional Test Failure Details\n\n")
+
+                    for question_key, data in sorted(additional_flaky.items()):
+                        entry = data["last_fail"]
+                        display_question = data["question"] if data["question"] else question_key
+                        md.write(f"##### `{display_question}`\n\n")
+                        md.write(f"**Failures:** {data['failures']} times\n\n")
+
+                        if data["test_names"]:
+                            test_names_str = ", ".join(f"`{tn}`" for tn in sorted(data["test_names"]))
+                            md.write(f"**Test Names:** {test_names_str}\n\n")
+
+                        if entry and entry.get("error_msg"):
+                            log = entry["error_msg"].strip()
+                            md.write("\n<details>\n")
+                            md.write("<summary><strong>View full failure log</strong></summary>\n\n")
+                            md.write("\n\n```\n")
+                            md.write(log)
+                            md.write("\n```\n")
+                            md.write("</details>\n\n---\n\n")
+
+                md.write("\n*Note: Connection failures (timeouts) are excluded from these statistics.*\n")
 
     print(f"Updated {REPORT_FILE}")
 


### PR DESCRIPTION
This PR makes the following improvements to my stability report in the orphan `stability-md` branch:

1. Group test results by Question instead of test name to make it robust to README changes.
2. Ignore connection failures e.g. timeouts

This PR does NOT affect any functionality in the demo.

Minor: I also registered a pytest marker to resolve that warning.

Here's the new look:

### 🧩 Stability Summary (2025-12-03)
*Aggregated from the last 10 days (2025-11-23 → 2025-12-03)*

#### ❗ Main Tests (Must be 100% Stable)
| Question | Failures | Passes | Failure Rate |
|----------|----------|--------|--------------|
| `Do miles in family pool expire?` | 6 | 107 | 5% |

---

#### 🔍 Main Test Failure Details

##### `Do miles in family pool expire?`

**Failures:** 6 times

**Test Names:** `tests/stable/test_guardrails.py::test_trustworthiness_guardrail_2`


<details>
<summary><strong>View full failure log</strong></summary>



```
AssertionError: Failed response: Miles in a Frontier Airlines Family Pool do not expire as long as there is accrual activity in the account every twelve months. This means that if any member of the pool generates activity, such as earning miles through purchases or other eligible activities, the miles for the entire pool will remain active.
  
  Criteria not met: trustworthiness threshold
assert 0.8773379302458094 < 0.77
```
</details>

---


#### 📊 Additional Tests (Some Instability Allowed)
| Question | Failures | Passes | Failure Rate |
|----------|----------|--------|--------------|
| `If both of my small bags fit completely under the seat in front of me without...` | 33 | 80 | 29% |
| `My flight got canceled how to use my Peace Pass benefit?` | 37 | 75 | 33% |
| `Tell me a joke about airlines` | 8 | 105 | 7% |
| `What's the capital of France?` | 4 | 109 | 4% |
| `Whats the maximum time we might be stuck on the tarmac without being let off ...` | 36 | 77 | 32% |
| `i saw your promo of a free discount den pass no enrollment fee and no annual ...` | 8 | 105 | 7% |

---

#### 🔍 Additional Test Failure Details

##### `If both of my small bags fit completely under the seat in front of me without taking any extra space, that counts as one personal item, correct?`

**Failures:** 33 times

**Test Names:** `tests/stable/test_guardrails.py::test_additional_trustworthiness_guardrail_3`


<details>
<summary><strong>View full failure log</strong></summary>



```
AssertionError: Failed response: Each passenger is allowed one personal item that must fit under the seat in front of them. If you have two small bags, each would be considered a separate personal item. Therefore, even if both bags fit under the seat, they would count as two personal items, not one. You are allowed only one personal item, so you would need to consolidate your belongings into a single bag to comply with the policy.

Criteria not met: The criterion requires the output to confirm that both of the user's small bags count as one personal item. The agent output explicitly states the opposite, saying each small bag would be considered a separate personal item and they would count as two personal items. Therefore it does not meet the criterion.
```
</details>

