### PR TITLE
Mutate tool templates

### DIFF
--- a/src/airline_agent/backend/services/airline_chat.py
+++ b/src/airline_agent/backend/services/airline_chat.py
@@ -207,7 +207,7 @@ async def airline_chat_streaming(
                 )
 
                 response_content = (
-                    "\n\n".join(mutate_tool_fallback_response)
+                    "I've completed the following for you:\n\n" + "\n\n".join(mutate_tool_fallback_response)
                     if validation_result.should_guardrail and mutate_tool_fallback_response
                     else final_response
                 )

--- a/src/airline_agent/constants.py
+++ b/src/airline_agent/constants.py
@@ -27,7 +27,7 @@ CONTEXT_RETRIEVAL_TOOLS = [
 AGENT_MODEL = "gpt-4o"
 FALLBACK_RESPONSE = "I'm sorry, but I don't have the information you're looking for. Please rephrase the question or contact Frontier Airlines customer support for further assistance."
 AGENT_INSTRUCTIONS = f"""
-You are an AI customer support agent for Frontier Airlines. You can use tools to access a knowledge base of articles and documents about the airline's services, policies, and procedures. You can help users find flight information and pricing, but you cannot book flights or make reservations.
+You are an AI customer support agent for Frontier Airlines. You can use tools to access a knowledge base of articles and documents about the airline's services, policies, and procedures. You can help users find flight information and pricing. You can also book flights.
 
 ## You have access to the following tools:
 - search — find candidate articles by query (keep top-k small, ≤5), returns title/snippet/path.
@@ -35,6 +35,11 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 - list_directory — list directory structure to make more informed searches.
 - search_flights — search available flights by origin and destination airport codes (IATA) and departure date (YYYY-MM-DD). Always ask for the departure date if the user doesn't provide it.
 - get_fare_details — retrieve fare bundle pricing, included services, and add-ons for a specific flight.
+- book_flights — book one or more flights for the current user. Requires list of flight IDs and fare bundle type (basic, economy, premium, business; defaults to basic). Returns booking confirmation with booking ID and total price.
+- get_booking — retrieve booking details by booking ID.
+- get_my_bookings — retrieve all confirmed bookings for the current user.
+- add_service_to_booking — add an eligible service (bags, seat selection, etc.) to a specific flight within a booking.
+- check_in — complete check-in for a specific flight in a booking.
 - get_flight_timings — get check-in, boarding, and door-close timing windows for a flight.
 - get_flight_status — get the latest status, gates, and delay information for a flight.
 
@@ -43,12 +48,15 @@ You are an AI customer support agent for Frontier Airlines. You can use tools to
 - Answer primarily based on information from retrieved content, unless the question is simply to clarify broadly understood aspects of commercial air travel (such as standard security procedures, boarding processes, or common airline terminology).
 - If a missing detail blocks tool use, ask one short clarifying question. If not blocking, proceed and state your assumption.
 - Don't dump raw tool output—summarize clearly.
+- When booking multiple flights (outbound and return), include all flight IDs in a single book_flights call.
 
 ## Response Guidelines:
 - Answer questions primarily based on information you look up in the knowledge base.
 - For requests that involve general airline knowledge that is not specific to Frontier Airlines (e.g., common terms, standard processes, and widely known industry roles), you may rely on your own knowledge if the knowledge base does not add important Frontier-specific details.
 - When responding to user, never use phrases like "according to the knowledge base", "I couldn't find anything in the knowledge base", etc. When responding to user, treat the retrieved knowledge base content as your own knowledge, not something you are referencing or searching through.
 - **If the user asks something unrelated to Frontier Airlines or air travel, politely refuse and redirect the conversation. Do not attempt to fulfill or improvise unrelated requests.**
+- When a booking is successfully created, provide the booking ID and confirmation details clearly.
+- If you book flights, provide the booking ID and summarize the flights booked and total price.
 - Avoid hedging language (e.g., “typically,” “generally,” “usually”) when the information is known and factual. Be clear and assertive in your response, and do not speculate.
 
 ## Context:

--- a/src/airline_agent/tools/booking.py
+++ b/src/airline_agent/tools/booking.py
@@ -562,14 +562,15 @@ class BookingTools:
 
     @property
     def tools(self) -> FunctionToolset:
-        # For now, only include read-only/informational tools.
-        #
-        # State mutation tools (book_flights, add_service_to_booking, check_in)
-        # and booking lookup tools (get_booking, get_my_bookings) are excluded.
         return FunctionToolset(
             tools=[
                 self.search_flights,
                 self.get_fare_details,
+                self.book_flights,
+                self.get_booking,
+                self.get_my_bookings,
+                self.add_service_to_booking,
+                self.check_in,
                 self.get_flight_timings,
                 self.get_flight_status,
             ]

--- a/src/airline_agent/tools/booking.py
+++ b/src/airline_agent/tools/booking.py
@@ -1,4 +1,6 @@
+import json
 import random
+from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -185,6 +187,33 @@ class BookingTools:
 
         return booking
 
+    def _format_service_type(self, service_type: str) -> str:
+        """Format service type from snake_case to Title Case with spaces."""
+        return service_type.replace("_", " ").title()
+
+    def _book_flights_to_string(self, result: str) -> str:
+        """Format book_flights result for fallback response."""
+        try:
+            booking_data = json.loads(result)
+            booking = Booking.model_validate(booking_data)
+
+            flight_parts = []
+            for i, flight_booking in enumerate(booking.flights, 1):
+                add_ons_text = (
+                    f". You also have the following add ons: {', '.join(self._format_service_type(ao.service_type) for ao in flight_booking.add_ons)}"
+                    if flight_booking.add_ons
+                    else ""
+                )
+                flight_parts.append(
+                    f"{i}. Flight {flight_booking.flight_id} ({flight_booking.fare_type} fare) ({flight_booking.currency} ${flight_booking.price_total:.2f}){add_ons_text}"
+                )
+
+            flights_text = " ".join(flight_parts)
+        except (json.JSONDecodeError, ValueError):
+            return result
+        else:
+            return f"Booking confirmed with booking ID {booking.booking_id} for a total price of {booking.currency} ${booking.total_price:.2f}. Flights: {flights_text}"
+
     def get_booking(self, booking_id: str) -> Booking:
         """
         Retrieve a booking by its booking ID.
@@ -324,6 +353,32 @@ class BookingTools:
         booking.status.updated_at = now
 
         return booking
+
+    def _add_service_to_booking_to_string(self, result: str) -> str:
+        """Format add_service_to_booking result for fallback response."""
+        try:
+            booking_data = json.loads(result)
+            booking = Booking.model_validate(booking_data)
+
+            # Find the flight that has the most recently added add-on
+            # (the one that was just modified)
+            service_parts = []
+            for flight_booking in booking.flights:
+                if flight_booking.add_ons:
+                    # Get the most recently added add-on
+                    latest_addon = max(flight_booking.add_ons, key=lambda ao: ao.added_at)
+                    add_ons_list = [self._format_service_type(ao.service_type) for ao in flight_booking.add_ons]
+                    add_ons_text = ", ".join(add_ons_list)
+                    price_text = f" ({booking.currency} ${latest_addon.price:.2f})" if latest_addon.price > 0 else ""
+                    service_parts.append(
+                        f"Added {self._format_service_type(latest_addon.service_type)}{price_text} to flight {flight_booking.flight_id}. Add-ons for this flight: {add_ons_text}"
+                    )
+
+            services_text = " ".join(service_parts)
+        except (json.JSONDecodeError, ValueError):
+            return result
+        else:
+            return f"Service added to booking {booking.booking_id}. {services_text}"
 
     def _assign_seat(self, flight_booking: FlightBooking, _flight_id: str) -> str:
         """Assign a seat to a flight booking based on preferences, fare type, or randomly."""
@@ -468,6 +523,29 @@ class BookingTools:
 
         return booking
 
+    def _check_in_to_string(self, result: str) -> str:
+        """Format check_in result for fallback response."""
+        try:
+            booking_data = json.loads(result)
+            booking = Booking.model_validate(booking_data)
+        except (json.JSONDecodeError, ValueError):
+            return result
+
+        # Find the flight that was checked in
+        checked_in_flights = [fb for fb in booking.flights if fb.checked_in]
+
+        if not checked_in_flights:
+            return f"Checked in for booking {booking.booking_id}."
+
+        check_in_parts = []
+        for flight_booking in checked_in_flights:
+            seat_text = (
+                f" Your seat assignment is {flight_booking.seat_assignment}." if flight_booking.seat_assignment else ""
+            )
+            check_in_parts.append(f"Checked in for flight {flight_booking.flight_id}.{seat_text}")
+
+        return " ".join(check_in_parts) if check_in_parts else f"Checked in for booking {booking.booking_id}."
+
     def get_flight_timings(self, flight_id: str) -> dict[str, Any]:
         """
         Get all timing windows for a flight (check-in, boarding, doors close, etc.).
@@ -575,3 +653,12 @@ class BookingTools:
                 self.get_flight_status,
             ]
         )
+
+    @property
+    def tool_fallback_fmt(self) -> dict[str, Callable[[str], str]]:
+        """Return formatters for mutative tools in this toolset."""
+        return {
+            "book_flights": self._book_flights_to_string,
+            "add_service_to_booking": self._add_service_to_booking_to_string,
+            "check_in": self._check_in_to_string,
+        }

--- a/src/airline_agent/tools/booking.py
+++ b/src/airline_agent/tools/booking.py
@@ -208,11 +208,11 @@ class BookingTools:
                     f"{i}. Flight {flight_booking.flight_id} ({flight_booking.fare_type} fare) ({flight_booking.currency} ${flight_booking.price_total:.2f}){add_ons_text}"
                 )
 
-            flights_text = " ".join(flight_parts)
+            flights_text = "\n".join(flight_parts)
         except (json.JSONDecodeError, ValueError):
             return result
         else:
-            return f"Booking confirmed with booking ID {booking.booking_id} for a total price of {booking.currency} ${booking.total_price:.2f}. Flights: {flights_text}"
+            return f"Booking confirmed with booking ID {booking.booking_id} for a total price of {booking.currency} ${booking.total_price:.2f}.\n\nFlights:\n{flights_text}"
 
     def get_booking(self, booking_id: str) -> Booking:
         """
@@ -371,14 +371,14 @@ class BookingTools:
                     add_ons_text = ", ".join(add_ons_list)
                     price_text = f" ({booking.currency} ${latest_addon.price:.2f})" if latest_addon.price > 0 else ""
                     service_parts.append(
-                        f"Added {self._format_service_type(latest_addon.service_type)}{price_text} to flight {flight_booking.flight_id}. Add-ons for this flight: {add_ons_text}"
+                        f"Added {self._format_service_type(latest_addon.service_type)}{price_text} to flight {flight_booking.flight_id}.\nYour add-ons for this flight are: {add_ons_text}"
                     )
 
-            services_text = " ".join(service_parts)
+            services_text = "\n\n".join(service_parts)
         except (json.JSONDecodeError, ValueError):
             return result
         else:
-            return f"Service added to booking {booking.booking_id}. {services_text}"
+            return services_text
 
     def _assign_seat(self, flight_booking: FlightBooking, _flight_id: str) -> str:
         """Assign a seat to a flight booking based on preferences, fare type, or randomly."""
@@ -544,7 +544,7 @@ class BookingTools:
             )
             check_in_parts.append(f"Checked in for flight {flight_booking.flight_id}.{seat_text}")
 
-        return " ".join(check_in_parts) if check_in_parts else f"Checked in for booking {booking.booking_id}."
+        return "\n".join(check_in_parts) if check_in_parts else f"Checked in for booking {booking.booking_id}."
 
     def get_flight_timings(self, flight_id: str) -> dict[str, Any]:
         """

--- a/tests/func/test_booking.py
+++ b/tests/func/test_booking.py
@@ -1,11 +1,13 @@
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any
 from unittest.mock import patch
+
+from codex.types.project_validate_response import ProjectValidateResponse
+from pydantic_ai.messages import ModelMessage
 
 from airline_agent.cleanlab_utils.validate_utils import run_cleanlab_validation_logging_tools
 from airline_agent.util import TestAgent as Agent
-from codex.types.project_validate_response import ProjectValidateResponse
-from pydantic_ai.messages import ModelMessage
 from tests.judge import assert_judge
 
 

--- a/tests/func/test_booking.py
+++ b/tests/func/test_booking.py
@@ -133,7 +133,7 @@ def test_add_service_to_booking_fallback() -> None:
 
 def test_check_in() -> None:
     agent = Agent(cleanlab_enabled=False)
-    agent.chat("Find flights from SFO to JFK on November 12, 2025")
+    agent.chat("Find flights from SFO to JFK on November 6, 2025")
     agent.chat("Book the first available flight")
     answer, _ = agent.chat("Check me in for my flight")
     assert_judge(

--- a/tests/func/test_booking.py
+++ b/tests/func/test_booking.py
@@ -145,7 +145,10 @@ def test_check_in_fallback() -> None:
     agent.chat("book me the F9 707 flight from SFO to LGA on 11/11")
     with mock_cleanlab_validation_with_guardrail():
         answer, _ = agent.chat("Check me in for my flight")
-        assert answer == "I've completed the following for you:\n\nChecked in for flight F9-SFO-LGA-2025-11-11T17:00. Your seat assignment is 19F."
+        assert (
+            answer
+            == "I've completed the following for you:\n\nChecked in for flight F9-SFO-LGA-2025-11-11T17:00. Your seat assignment is 19F."
+        )
 
 
 def test_flight_status() -> None:

--- a/tests/func/test_booking.py
+++ b/tests/func/test_booking.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from unittest.mock import patch
 
+from airline_agent.cleanlab_utils.validate_utils import run_cleanlab_validation_logging_tools
 from airline_agent.util import TestAgent as Agent
 from tests.judge import assert_judge
 
@@ -8,7 +9,6 @@ from tests.judge import assert_judge
 @contextmanager
 def mock_cleanlab_validation_with_guardrail():
     """Context manager that mocks cleanlab validation to always set should_guardrail=True."""
-    from airline_agent.cleanlab_utils.validate_utils import run_cleanlab_validation_logging_tools
 
     def mock_validation(*args, **kwargs):
         updated_message_history, final_response, validation_result = run_cleanlab_validation_logging_tools(

--- a/tests/func/test_booking.py
+++ b/tests/func/test_booking.py
@@ -1,16 +1,19 @@
 from contextlib import contextmanager
+from typing import Any, Iterator
 from unittest.mock import patch
 
 from airline_agent.cleanlab_utils.validate_utils import run_cleanlab_validation_logging_tools
 from airline_agent.util import TestAgent as Agent
+from codex.types.project_validate_response import ProjectValidateResponse
+from pydantic_ai.messages import ModelMessage
 from tests.judge import assert_judge
 
 
 @contextmanager
-def mock_cleanlab_validation_with_guardrail():
+def mock_cleanlab_validation_with_guardrail() -> Iterator[None]:
     """Context manager that mocks cleanlab validation to always set should_guardrail=True."""
 
-    def mock_validation(*args, **kwargs):
+    def mock_validation(*args: Any, **kwargs: Any) -> tuple[list[ModelMessage], str, ProjectValidateResponse]:
         updated_message_history, final_response, validation_result = run_cleanlab_validation_logging_tools(
             *args, **kwargs
         )


### PR DESCRIPTION
Notion ticket: https://www.notion.so/cleanlab/Mutative-tool-fallback-responses-2c0c7fee85be80b19645df046150bc08?source=copy_link

This PR re-introduces mutative tools by fixing the issue of guardrailed responses after mutative tools => user doesn't know that mutative action was done.

Example of issue:
<img width="1662" height="1770" alt="example of guardrailed response after mutative tool" src="https://github.com/user-attachments/assets/9a831b8b-adc6-43e4-98da-14ebdc47c80a" />

Fix is to have the develop provide a template fallback for each mutative tool. If final response is guardrailed, collate the fallbacks for each tool into one response e.g.

<img width="788" height="826" alt="image" src="https://github.com/user-attachments/assets/cbc28669-d8c4-4bf7-bb4b-1afa2e28534c" />
(Final assistant response was guardrailed)



TODO: Codex backend needs to be updated to take the developer's fallback response and show that instead of the Cleanlab fallback to maintain visibility. That will be fixed by this ticket: https://www.notion.so/cleanlab/Mutative-tool-fallback-responses-2c0c7fee85be80b19645df046150bc08?source=copy_link

